### PR TITLE
removes unnecessary package com.example.app

### DIFF
--- a/stage #0/module #6. OOP Fundamentals/content.md
+++ b/stage #0/module #6. OOP Fundamentals/content.md
@@ -369,7 +369,6 @@ public class AppClass {
 
 ### Static class members
 If it is required that all objects of a class were using the same field or method, it may be marked with a keyword `static`.
-package com.example.app;
 ```
 package com.example.app;
 


### PR DESCRIPTION
Fix typo by removing unnecessary `package com.example.app;` in the stage #0/module #6. OOP Fundamentals/content.md file.